### PR TITLE
Shift multiple plots correctly

### DIFF
--- a/inspector3D/visualizer.py
+++ b/inspector3D/visualizer.py
@@ -426,18 +426,19 @@ class Visualizer(object):
         self.w.setCameraParams(distance=camera_distance)
 
         # center data around [0, 0, 0] so that camera points on center
-        all_coordinates = np.concatenate(coordinates, axis=1)
-        mean_coordinates = all_coordinates.mean(axis=(0, 1))
         y_ranges = np.zeros([len(coordinates), ])
         if self.shift:
             for i in range(len(y_ranges)):
                 y_ranges[i] = coordinates[i][:, :, 1].max() - coordinates[i][:, :, 1].min()
             y_ranges = [np.array(y_ranges).max()] * np.array(range(0, len(y_ranges)))
             # y_ranges = np.array([0] + y_ranges)
-        coordinates = [(XYZ - mean_coordinates) + np.array([0, 1.1 * y_ranges[i], 0]) for i, XYZ in
-                       enumerate(coordinates)]
+        # Apply shifting
+        coordinates = [XYZ + np.array([0, 1.1 * y_ranges[i], 0]) for i, XYZ in enumerate(coordinates)]
+        # Re-center plots after shifting
+        all_coordinates = np.concatenate(coordinates, axis=1)
+        mean_coordinates = all_coordinates.mean(axis=(0, 1))
+        coordinates = [(XYZ - mean_coordinates) for i, XYZ in enumerate(coordinates)]
 
-        # generate random points from -10 to 10, z-axis positive]
         self.coords = []
         for coord in coordinates:
             self.coords.append(coord)


### PR DESCRIPTION
Maybe it was only a problem on my machine, but I get following results for the `disc_brake_example.py`

Before fff591b:
![Screenshot from 2023-05-15 19-35-31](https://github.com/jkneifl/Inspector3D/assets/43179176/c6f87ced-26d9-4457-9fcd-f74258f96c48)

After fff591b (just uncommenting some lines):
![Screenshot from 2023-05-15 19-32-44](https://github.com/jkneifl/Inspector3D/assets/43179176/cdc649f8-44a5-4114-aaaf-45099dcdd812)

After d88597f, which is the correct result:
![Screenshot from 2023-05-15 19-42-39](https://github.com/jkneifl/Inspector3D/assets/43179176/13ec7140-3a7e-469e-8727-b1d178f550ab)

